### PR TITLE
Add NLTK summarization and web UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,5 @@ json/
 *.log
 firebase.json
 .firebaserc
-index.html
 aerthexv_final.py
 chat_summarizer_v3_optimized.py

--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
 # Discord Chat Summarizer AI
 
-This project provides tools for summarizing conversations, targeting Discord chat logs.  
-It includes a minimal API endpoint, utility helpers, and an early user interface scaffold.
+This project provides tools for summarizing conversations, targeting Discord chat logs.
+It includes a JSON API endpoint with an extractive summarisation engine and a very
+lightweight web interface for experimenting with the feature.
 
 ## Features
-- Simple HTTP API for receiving chat messages and returning a placeholder summary.
+- HTTP API (`/api/index`) that accepts chat text and returns a condensed summary.
+- Extractive summariser implemented with `nltk` for deterministic results.
+- Simple HTML/JS front-end served from `index.html` for manual testing.
 - Utility helpers for common tasks such as logging and directory creation.
 - Basic test suite executed with `pytest`.
 
 ## Deployment
-Deploying the repository on [Vercel](https://vercel.com) will expose the API at the root URL.
-The serverless function lives in `api/index.py` and returns a basic JSON health message
-to confirm the deployment is working.
+Deploying the repository on [Vercel](https://vercel.com) will expose the static
+front-end at the root URL and the API under `/api/index`.
+The serverless function lives in `api/index.py` and returns a health message as
+well as handling chat summarisation requests.
 
 ## Installation
 1. Create and activate a virtual environment.

--- a/api/index.py
+++ b/api/index.py
@@ -1,10 +1,74 @@
-import json
+"""Serverless entrypoint for Vercel.
 
-def handler(request):
-    """Vercel entrypoint returning a basic health message."""
-    body = {"message": "Discord Chat Summarizer API is running"}
+This module exposes a ``handler`` function compatible with Vercel's Python
+runtime.  Besides a basic health check it also exposes a minimal JSON API that
+accepts ``POST`` requests containing a ``text`` field and returns a condensed
+summary.  The implementation relies on :mod:`nltk` for an extractive
+summarisation algorithm.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from http import HTTPStatus
+
+# Ensure the project root is on the import path when executed by Vercel.
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from src.services.summarizer import summarize_text
+
+
+def _json_response(body: dict, status: HTTPStatus = HTTPStatus.OK) -> dict:
+    """Return a JSON HTTP response understood by Vercel.
+
+    Parameters
+    ----------
+    body:
+        Dictionary that will be JSON serialised.
+    status:
+        HTTP status code for the response.
+    """
+
     return {
-        "statusCode": 200,
-        "headers": {"Content-Type": "application/json"},
+        "statusCode": int(status),
+        "headers": {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+            "Access-Control-Allow-Headers": "Content-Type",
+        },
         "body": json.dumps(body),
     }
+
+
+def handler(request):  # pragma: no cover - exercised via tests
+    """Entry point for Vercel.
+
+    * ``GET`` requests return a simple health message.
+    * ``POST`` requests expect a JSON body with a ``text`` field and return a
+      generated summary.
+    * ``OPTIONS`` requests are answered to satisfy CORS pre-flight checks.
+    """
+
+    method = getattr(request, "method", "GET").upper()
+
+    if method == "OPTIONS":
+        return _json_response({}, HTTPStatus.NO_CONTENT)
+
+    if method == "POST":
+        try:
+            payload = json.loads(getattr(request, "body", "{}"))
+        except json.JSONDecodeError:
+            return _json_response({"error": "Invalid JSON payload"}, HTTPStatus.BAD_REQUEST)
+
+        text = (payload.get("text") or "").strip()
+        if not text:
+            return _json_response({"error": "Missing 'text' field"}, HTTPStatus.BAD_REQUEST)
+
+        summary = summarize_text(text)
+        return _json_response({"summary": summary})
+
+    # Default to health message for all other methods (e.g. GET)
+    return _json_response({"message": "Discord Chat Summarizer API is running"})

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Discord Chat Summarizer AI</title>
+</head>
+<body>
+    <h1>Discord Chat Summarizer AI</h1>
+    <textarea id="chatInput" rows="10" cols="80" placeholder="Paste chat text here..."></textarea><br>
+    <button id="summarizeBtn">Summarize</button>
+    <h2>Summary</h2>
+    <pre id="summaryOutput"></pre>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 aiohttp
+nltk

--- a/script.js
+++ b/script.js
@@ -1,0 +1,12 @@
+async function summarize() {
+  const text = document.getElementById('chatInput').value;
+  const res = await fetch('/api/index', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({text})
+  });
+  const data = await res.json();
+  document.getElementById('summaryOutput').textContent = data.summary || data.error || 'No summary returned';
+}
+
+document.getElementById('summarizeBtn').addEventListener('click', summarize);

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,1 +1,5 @@
-# Initialize the services package
+"""Utility services used across the project."""
+
+from .summarizer import summarize_text
+
+__all__ = ["summarize_text"]

--- a/src/services/summarizer.py
+++ b/src/services/summarizer.py
@@ -1,0 +1,60 @@
+"""Text summarisation utilities.
+
+This module exposes a small extractive summariser based on word frequency using
+:mod:`nltk`.  It is intentionally lightweight yet provides deterministic
+summaries suitable for quick previews on the front-end.
+"""
+
+from __future__ import annotations
+
+import heapq
+import re
+from typing import List
+
+import nltk
+from nltk.tokenize import sent_tokenize, word_tokenize
+
+# Ensure required tokenizer models are available at runtime.
+nltk.download("punkt", quiet=True)
+nltk.download("punkt_tab", quiet=True)
+
+
+def _clean_words(words: List[str]) -> List[str]:
+    """Return alphanumeric tokens in lower case."""
+    return [re.sub(r"[^a-zA-Z0-9]", "", w).lower() for w in words if w.isalnum()]
+
+
+def summarize_text(text: str, max_sentences: int = 2) -> str:
+    """Return an extractive summary of ``text``.
+
+    Parameters
+    ----------
+    text:
+        Text to summarise.
+    max_sentences:
+        Maximum number of sentences to return in the summary.
+    """
+
+    sentences = sent_tokenize(text)
+    if not sentences:
+        return ""
+    if len(sentences) <= max_sentences:
+        return text.strip()
+
+    words = _clean_words(word_tokenize(text))
+    freq = {}
+    for word in words:
+        freq[word] = freq.get(word, 0) + 1
+
+    sentence_scores = {}
+    for idx, sentence in enumerate(sentences):
+        for word in _clean_words(word_tokenize(sentence)):
+            if word in freq:
+                sentence_scores[idx] = sentence_scores.get(idx, 0) + freq[word]
+
+    # Choose the highest scoring sentences and preserve their original order.
+    top_indices = sorted(
+        heapq.nlargest(max_sentences, sentence_scores, key=sentence_scores.get)
+    )
+    summary = " ".join(sentences[i] for i in top_indices)
+    return summary.strip()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,8 +8,9 @@ from api.index import handler
 
 
 class DummyRequest:
-    def __init__(self):
-        self.method = "GET"
+    def __init__(self, method="GET", body=""):
+        self.method = method
+        self.body = body
 
 
 def test_handler_returns_health_message():
@@ -17,3 +18,13 @@ def test_handler_returns_health_message():
     assert response["statusCode"] == 200
     body = json.loads(response["body"])
     assert body["message"].startswith("Discord Chat Summarizer API")
+
+
+def test_handler_summarizes_text():
+    text = "Sentence one. Sentence two about cats. Sentence three about cats and dogs."
+    request = DummyRequest(method="POST", body=json.dumps({"text": text}))
+    response = handler(request)
+    assert response["statusCode"] == 200
+    data = json.loads(response["body"])
+    assert "summary" in data
+    assert len(data["summary"]) < len(text)

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "version": 2,
-  "functions": {"api/index.py": {"runtime": "python3.9"}},
-  "routes": [{"src": "/.*", "dest": "api/index.py"}]
+  "functions": {
+    "api/index.py": {"runtime": "python3.9"}
+  }
 }


### PR DESCRIPTION
## Summary
- enhance serverless API with NLTK-based text summarization and CORS support
- add minimal HTML/JS interface for sending chat text to the API
- document new features and update dependency list

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896ac2138b08323995e3c9df801347e